### PR TITLE
Make buildout.bootstrap honor "-o" aka "offline = true" mode

### DIFF
--- a/buildout/bootstrap/__init__.py
+++ b/buildout/bootstrap/__init__.py
@@ -1,8 +1,7 @@
 import urllib
 
-line = ('----------------------------------------' +
-        '----------------------------------------')
-
+line = '-' * 80
+truthiness = ('true', 'yes', 'on')
 
 def install(buildout, open_=None):
     """
@@ -13,6 +12,10 @@ def install(buildout, open_=None):
         $ curl -O https://raw.github.com/buildout/buildout/1.6.x/bootstrap/bootstrap.py
 
     """
+    offline = buildout['buildout'].get('offline', 'true').lower()
+    if offline in truthiness:
+        print 'Not updating bootstrap.py because buildout is in offline mode.'
+        return
     # 1.6.x bootstrap
     url = 'https://raw.github.com/buildout/buildout/1.6.x/bootstrap/bootstrap.py'
     try:


### PR DESCRIPTION
Currently, if the buildout is run with "-o" (or if "offline = true" appears in the [buildout]), the buildout.bootstrap extension will go ahead and "go online" to fetch a new bootstrap.py.

This small update has it honor the "-o" (offline = true) mode.

It also (cosmetically) re-defines the "line" global.
